### PR TITLE
v2.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,15 +6,21 @@ max-len: ["error", 80]
 */
 'use strict'
 
+const isObject  = require('is.object')
+const size      = require('object.size')
+
 module.exports = formatParams
 
 function formatParams (path, params) {
+  if (!isObject(params) || !size(params)) {
+    return path
+  }
+
   const arr = path.split('/')
   const len = arr.length
-  let i = 0
 
-  for (; i < len; i++) {
-    const found = params[arr[i]]
+  for (let i = 0; i < len; i++) {
+    let found = params[arr[i]]
 
     if (found) {
       arr[i] = found

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-params",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "a simple way to format params for an http request",
   "main": "index.js",
   "files": [
@@ -47,5 +47,9 @@
   "pre-commit": [
     "test",
     "coverage:check"
-  ]
+  ],
+  "dependencies": {
+    "is.object": "^1.0.0",
+    "object.size": "^1.0.0"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -8,7 +8,21 @@ max-len: ["error", 80]
 
 const test = require('tape')
 
-const formatParams = require('./')
+const formatParams = require('./index')
+
+test('should return the original path if params is not a valid plain object',
+  function (assert) {
+    assert.deepEqual(formatParams('/id', undefined), '/id')
+    assert.end()
+  }
+)
+
+test('should return the original path if params is an empty object',
+  function (assert) {
+    assert.deepEqual(formatParams('/id', {}), '/id')
+    assert.end()
+  }
+)
 
 test('format with one param', function (assert) {
   assert.deepEqual(formatParams('/id', { id: 123 }), '/123')


### PR DESCRIPTION
when `params` object is not valid should return the original `path`